### PR TITLE
Fixed dependency bug for ProgressBar methods - MANU-5760

### DIFF
--- a/lib/dictionary_to_terms/recordings_importer.rb
+++ b/lib/dictionary_to_terms/recordings_importer.rb
@@ -58,7 +58,7 @@ module DictionaryToTerms
         limit = current + INTERVAL
         limit = to if limit > to
         limit = rows.size if limit > rows.size
-        RecordingsImporter.wait_if_business_hours(daylight)
+        self.wait_if_business_hours(daylight)
         sid = Spawnling.new do
           self.log.debug { "#{Time.now}: Spawning sub-process #{Process.pid}." }
           for i in current...limit

--- a/lib/dictionary_to_terms/version.rb
+++ b/lib/dictionary_to_terms/version.rb
@@ -1,3 +1,3 @@
 module DictionaryToTerms
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-5760

**Changes proposed in this pull request:**

 + Fixed instance Dependency bug on KmapsEngine::ProgressBar

**Details of the implementation:**

Now using the method wait_if_business_hours as an instance method.

Engine version upgraded to v0.3.3